### PR TITLE
refactor: add cleanup method

### DIFF
--- a/src/service.cc
+++ b/src/service.cc
@@ -86,6 +86,7 @@ void EcapStream::Service::start() {
         send = (void (*)(int, const void*, size_type))dlsym(_module, "receive");
         receive = (Chunk (*)(int, size_type, size_type))dlsym(_module, "send");
         done = (void (*)(int))dlsym(_module, "done");
+        cleanup = (void (*)(int))dlsym(_module, "cleanup");
         std::clog << "Ecap-Stream started." << std::endl;
     } else {
         std::clog << "Ecap-Stream failed starting. Check the 'modulePath' configuration." << std::endl;
@@ -106,6 +107,7 @@ void EcapStream::Service::retire() {
     send = 0;
     receive = 0;
     done = 0;
+    cleanup = 0;
 }
 
 bool EcapStream::Service::wantsUrl(const char *url) const {

--- a/src/service.h
+++ b/src/service.h
@@ -40,6 +40,7 @@ namespace EcapStream {
             void (*send)(int, const void*, size_type);
             Chunk (*receive)(int, size_type, size_type);
             void (*done)(int);
+            void (*cleanup)(int);
         private:
             void* _module;
             std::string _modulePath;

--- a/src/xaction.h
+++ b/src/xaction.h
@@ -47,13 +47,10 @@ namespace EcapStream {
             libecap::shared_ptr<libecap::Message>  adapted;
             libecap::host::Xaction *hostx;
 
-            int id = 0;
-            int contentLength = 0;
+            int _id = 0;
             char* _uri = 0;
 
-            static int counter;
-            static libecap::Name headerContentEncoding;
-
+            static int _counter;
     };
 
 


### PR DESCRIPTION
What used to be the "commit" function,
previously removed.